### PR TITLE
fix: sometimes not rendering images

### DIFF
--- a/templates/image-hover-template.html
+++ b/templates/image-hover-template.html
@@ -1,7 +1,7 @@
 <div id="{{id}}" class="{{classes}}">
 	{{#if isImage}}
-  		<img src={{url}} style="width:100%;"></img>
+  		<img src="{{url}}" style="width:100%;"></img>
 	{{else}}
-  		<video src={{url}} autoplay loop style="width:100%;"></video>
+  		<video src="{{url}}" autoplay loop style="width:100%;"></video>
 	{{/if}}
 </div>


### PR DESCRIPTION
Some images with spaces in their names don't render without the quotes