### PR TITLE
Console error fixes, single event triggered on key down

### DIFF
--- a/image-hover.js
+++ b/image-hover.js
@@ -255,10 +255,13 @@ Hooks.on("renderHeadsUpDisplay", (app, html, data) => {
 
 Hooks.on("createToken", (scene, data) => {
     const tokenId = game.actors.get(data.actorId);
+    
+    if (!tokenId) return;
+
     let imageToCache = tokenId.img;
     if (imageToCache === DEFAULT_TOKEN) {
         imageToCache = data.img;
-    };
+    }
     if (!(imageToCache in cacheImageNames)) {
         canvas.hud.imageHover.cacheAvailableToken(imageToCache, false, false)
     }

--- a/image-hover.js
+++ b/image-hover.js
@@ -320,12 +320,19 @@ Hooks.on("closeSettingsConfig", function() {
 /**
  * add event listener when keybind setting is activated
  */
+var handledEvent = false;
 document.addEventListener('keydown', event => {
-	if (keybindActive && window.Azzu.SettingsTypes.KeyBinding.eventIsForBinding(event, keybindKeySet)) {
+	if (keybindActive && window.Azzu.SettingsTypes.KeyBinding.eventIsForBinding(event, keybindKeySet) && !handledEvent) {
+        handledEvent = true;
         const hoveredToken = canvas.tokens._hover
         if (hoveredToken !== null) {
             canvas.hud.imageHover.showArtworkRequirements(hoveredToken, true);
         }
+    }
+});
+document.addEventListener('keyup', event => {
+	if (keybindActive && window.Azzu.SettingsTypes.KeyBinding.eventIsForBinding(event, keybindKeySet) && handledEvent) {
+        handledEvent = false;
     }
 });
 


### PR DESCRIPTION
The first commit handles issues where there are multiple tokens on initially loading a scene. The console log was reporting an error stating that img is not defined for each token (createToken is called on initial startup). This seemed to only occur with a lot of tokens.

The second commit makes it so that holding down 'v' (or whatever keybind) will only trigger the keydown event once, instead of over and over again while you hold the key down. This makes it so you have to hover over the token first before pressing v before image hover triggers, so let me know if you'd prefer not to use this commit and I can remove it.