### PR TITLE
Release refers to specific image hover version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       env:
         version: ${{github.event.release.tag_name}}
         url: https://github.com/${{github.repository}}
-        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        manifest: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.json
         download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
 
     # Create a zip file with all files required by the module to add to the release


### PR DESCRIPTION
update the manifest pipeline to refer to a specific release. 
Avoid update clashes between new Foundry versions.

**Manifest no longer refers to latest release but to the current version.**