### PR TITLE
Canvas layer isn't guaranteed to be set.

### DIFF
--- a/image-hover.js
+++ b/image-hover.js
@@ -377,6 +377,7 @@ class ImageHoverHUD extends BasePlaceableHUD {
 
     if (
       hovered &&
+      canvas.activeLayer &&
       (canvas.activeLayer.name == "TokenLayer" ||
         canvas.activeLayer.name == "TokenLayerPF2e")
     ) {


### PR DESCRIPTION
Saw "TypeError: Error thrown in hooked function '' for hook 'hoverToken'. canvas.activeLayer is null [Detected 2 packages: image-hover, system:pf2e]    showArtworkRequirements https://foundry.xdy.se:30201/modules/image-hover/image-hover.js:380" in the log.
Might be an interaction with some other module/only happen in pf2e, but the fix in this commit should be safe for all systems.