### PR TITLE
Add option to not show image if token has detection filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Version history
 
+## NEXT
+
+- Add option to never show image for tokens which have a detectionFilter applied to them (this works for the "imprecise" sense in PF2E).
+
 ## Version 3.0.3
 
 - Update to be Foundry v11 compatible

--- a/image-hover.js
+++ b/image-hover.js
@@ -341,6 +341,11 @@ class ImageHoverHUD extends BasePlaceableHUD {
     if (token.document.getFlag("image-hover", "hideArt")) return;
 
     /**
+     * option to never show image of a token subject to filtering (e.g. imprecise vision on PF2E)
+     */
+    if (game.settings.get("image-hover", "onlyNoDetection") && token.detectionFilter) return;
+
+    /**
      * Do not show art for chat portrait module (hover hook doesn't trigger out properly).
      */
     if (chatPortraitActive) {

--- a/settings.js
+++ b/settings.js
@@ -141,5 +141,17 @@ export class Settings {
       default: 0, // Default Value
       type: Number, // Value type
     });
+
+    // client setting
+    game.settings.register("image-hover", "onlyNoDetection", {
+      name: "Only Token with no detection filter", // Setting name
+      hint: "Only show Images with no detection filter on them (such as 'imprecise' sense on Pathfinder 2E)", // Setting description
+      scope: "world", // client-stored setting
+      config: true, // Show setting in configuration view
+      type: Boolean, // Value type
+      default: true // The default value for the setting
+    });
+
+
   }
 }


### PR DESCRIPTION
In Pathfinder 2E there is an "imprecise" sense option which displays a filter over the token (e.g. when the token is blind, but can still hear the target). Image Hover currently will display the image of the token clearly, thus reducing the experience for the player.

This pull request adds a simple check that the token has no "detectionFilter" on it before displaying the hover image (with a module setting to disable this function).  I've defaulted the setting to ON, so that users of the module will immediately see the benefits.